### PR TITLE
不具合を修正

### DIFF
--- a/services/learner/util/word.py
+++ b/services/learner/util/word.py
@@ -65,8 +65,9 @@ def get_body_from_URL(url: str) -> tuple[str, str]:
         html = soup.get_text()
     else:
         html = '\n'.join([c.get_text() for c in soup.find_all('article')])
-    return soup.title.string, strip_symbol(strip_tags(strip_url(neologdn.normalize(html))))
-
+    if soup.title:
+        return soup.title.string, strip_symbol(strip_tags(strip_url(neologdn.normalize(html))))
+    return "", strip_symbol(strip_tags(strip_url(neologdn.normalize(html))))
 
 def allow_robots_txt(url: str) -> bool:
     rp = RobotFileParser()

--- a/services/web/src/components/Atodeyomu.tsx
+++ b/services/web/src/components/Atodeyomu.tsx
@@ -45,7 +45,7 @@ export const Atodeyomu = (props: any) => {
             { entries.length > 0 && (
                 <ol>
                     {entries.map(entry => (
-                        <li key={entry.getTitle()}>
+                        <li key={entry.getLink()}>
                             <a href={entry.getLink()}>
                                 {entry.getTitle()}
                             </a>

--- a/services/web/src/components/Hotentry.tsx
+++ b/services/web/src/components/Hotentry.tsx
@@ -73,7 +73,7 @@ export const Hotentory = (props: any) => {
             { hotentries.length > 0 && (
                 <ol>
                     {hotentries.map(entry => (
-                        <li key={entry.getTitle()}>
+                        <li key={entry.getLink()}>
                             <a href={entry.getLink()}>
                                 {entry.getTitle()}
                             </a> ({entry.getScore().toFixed(2)})


### PR DESCRIPTION
Reactのリスト表示のキーを、リンクではなくタイトルにしていたのでリンクに修正。

PDFファイルなど、タイトルがないブックマークのタイトルを取得しようとするとエラーになってしまうことに気づいたため、タイトルを確認する処理を追加。